### PR TITLE
Add modular MCQ video automation scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore environment and output files
+.env
+output/
+pipeline.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -167,3 +167,9 @@ Execute the script to process each row in the spreadsheet:
 python youtube_workflow.py
 ```
 The script generates videos in the `output/` directory, uploads them if the YouTube API is available, logs the upload in `workflow.db`, and sends an email notification.
+
+---
+
+## MCQ Video Pipeline
+
+The `mcq_video_pipeline` folder contains a more modular setup to automate multiple-choice question explainer videos. Each step (data retrieval, voiceover, video creation, upload, playlist management, logging, and email notification) lives in its own module for easy maintenance. See [`mcq_video_pipeline/README.md`](mcq_video_pipeline/README.md) for configuration and usage details.

--- a/mcq_video_pipeline/README.md
+++ b/mcq_video_pipeline/README.md
@@ -1,0 +1,55 @@
+# MCQ Video Pipeline
+
+This directory contains a modular pipeline for generating multiple-choice question explainer videos and uploading them to YouTube.
+
+## Directory Structure
+
+```
+mcq_video_pipeline/
+│   main.py                 # Entry point for generating videos
+│   data_retrieval.py       # Load questions from Google Sheets
+│   content_generation.py   # Build narration scripts
+│   voiceover.py            # Text-to-speech utilities
+│   video_creation.py       # Assemble video clips with moviepy
+│   upload.py               # Upload videos to YouTube and Google Drive
+│   playlist.py             # Playlist creation and management
+│   logging_util.py         # SQLite logging helpers
+│   email_notification.py   # Send status emails
+│   requirements.txt        # Python dependencies
+└── README.md
+```
+
+### Setup
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file in this directory with your API keys and credentials. Example:
+   ```bash
+   GOOGLE_SERVICE_ACCOUNT_FILE=path/to/service_account.json
+   GOOGLE_SHEETS_URL=https://docs.google.com/...
+   YOUTUBE_CLIENT_SECRETS=client_secrets.json
+   EMAIL_SENDER=you@example.com
+   EMAIL_PASSWORD=your-email-password
+   EMAIL_RECEIVER=notify@example.com
+   ELEVEN_LABS_KEY=optional-elevenlabs
+   ```
+
+### Running
+Run the pipeline manually with:
+```bash
+python main.py
+```
+To automate daily processing of five new videos, configure a cron job or GitHub Action that calls `python main.py` each day.
+
+### Module Overview
+- **data_retrieval.py** – Connects to Google Sheets using gspread and fetches new rows for processing.
+- **content_generation.py** – Builds text scripts from the question, explanation, and strategy tip fields.
+- **voiceover.py** – Generates speech audio with gTTS or ElevenLabs.
+- **video_creation.py** – Creates videos with intro/outro branding, text slides, countdown timer, and embeds voiceover using moviepy.
+- **upload.py** – Handles YouTube upload, Google Drive backup, and returns the video ID.
+- **playlist.py** – Checks if a playlist exists for the subject, creates one if needed, and adds the video to it.
+- **logging_util.py** – Records processing status and video metadata to an SQLite database.
+- **email_notification.py** – Sends an email with the video link and playlist after successful upload.
+
+This scaffold provides a starting point. Fill in each module with your desired logic to create a fully automated educational YouTube pipeline.

--- a/mcq_video_pipeline/content_generation.py
+++ b/mcq_video_pipeline/content_generation.py
@@ -1,0 +1,16 @@
+"""Create narration script from MCQ data."""
+from typing import Dict
+
+
+def build_script(row: Dict[str, str]) -> str:
+    question = row.get("Question", "")
+    answer = row.get("Answer", "")
+    explanation = row.get("Explanation", "")
+    tip = row.get("Strategy Tip", "")
+    script = (
+        f"Question: {question}. "
+        f"The correct answer is {answer}. "
+        f"Explanation: {explanation}. "
+        f"Strategy tip: {tip}."
+    )
+    return script

--- a/mcq_video_pipeline/data_retrieval.py
+++ b/mcq_video_pipeline/data_retrieval.py
@@ -1,0 +1,26 @@
+"""Module to load MCQ data from Google Sheets."""
+from typing import List, Dict
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SHEETS_URL = os.getenv("GOOGLE_SHEETS_URL")
+SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_SERVICE_ACCOUNT_FILE")
+
+
+def fetch_rows(limit: int = 5) -> List[Dict[str, str]]:
+    """Fetch rows from Google Sheets and return a list of dictionaries."""
+    scope = [
+        "https://spreadsheets.google.com/feeds",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(
+        SERVICE_ACCOUNT_FILE, scope
+    )
+    gc = gspread.authorize(credentials)
+    sheet = gc.open_by_url(SHEETS_URL).sheet1
+    rows = sheet.get_all_records()
+    return rows[:limit]

--- a/mcq_video_pipeline/email_notification.py
+++ b/mcq_video_pipeline/email_notification.py
@@ -1,0 +1,25 @@
+"""Send email notifications."""
+import smtplib
+from email.message import EmailMessage
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+EMAIL_SENDER = os.getenv("EMAIL_SENDER")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+EMAIL_RECEIVER = os.getenv("EMAIL_RECEIVER")
+
+
+def send_email(subject: str, body: str) -> None:
+    if not (EMAIL_SENDER and EMAIL_PASSWORD and EMAIL_RECEIVER):
+        print("Email credentials missing")
+        return
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = EMAIL_SENDER
+    msg["To"] = EMAIL_RECEIVER
+    msg.set_content(body)
+    with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
+        smtp.login(EMAIL_SENDER, EMAIL_PASSWORD)
+        smtp.send_message(msg)

--- a/mcq_video_pipeline/logging_util.py
+++ b/mcq_video_pipeline/logging_util.py
@@ -1,0 +1,40 @@
+"""SQLite logging utilities."""
+import sqlite3
+from pathlib import Path
+from typing import Dict
+
+DB_FILE = Path("pipeline.db")
+
+
+def init_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_FILE)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS videos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            subject TEXT,
+            topic TEXT,
+            question TEXT,
+            video_id TEXT,
+            playlist_id TEXT,
+            status TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    return conn
+
+
+def log_video(conn: sqlite3.Connection, data: Dict[str, str]) -> None:
+    conn.execute(
+        "INSERT INTO videos (subject, topic, question, video_id, playlist_id, status) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            data.get("Subject"),
+            data.get("Topic"),
+            data.get("Question"),
+            data.get("video_id"),
+            data.get("playlist_id"),
+            data.get("status", "uploaded"),
+        ),
+    )
+    conn.commit()

--- a/mcq_video_pipeline/main.py
+++ b/mcq_video_pipeline/main.py
@@ -1,0 +1,55 @@
+"""Entry point for MCQ video pipeline."""
+from pathlib import Path
+from data_retrieval import fetch_rows
+from content_generation import build_script
+from voiceover import create_voiceover
+from video_creation import create_video
+from upload import upload_to_youtube, backup_to_drive
+from playlist import get_or_create_playlist, add_video_to_playlist
+from logging_util import init_db, log_video
+from email_notification import send_email
+
+OUTPUT_DIR = Path("output")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def process_row(row):
+    script = build_script(row)
+    voice_path = OUTPUT_DIR / f"{row['Topic']}_narration.mp3"
+    create_voiceover(script, voice_path)
+
+    video_path = OUTPUT_DIR / f"{row['Topic']}.mp4"
+    create_video(row, voice_path, video_path)
+
+    video_id = upload_to_youtube(video_path, row['Topic'], row['Explanation'])
+    backup_to_drive(video_path)
+
+    playlist_id = get_or_create_playlist(row['Subject'])
+    add_video_to_playlist(video_id, playlist_id)
+
+    db = init_db()
+    log_video(
+        db,
+        {
+            "Subject": row["Subject"],
+            "Topic": row["Topic"],
+            "Question": row["Question"],
+            "video_id": video_id,
+            "playlist_id": playlist_id,
+        },
+    )
+
+    send_email(
+        "Video uploaded",
+        f"Video: https://youtu.be/{video_id}\nPlaylist: {playlist_id}",
+    )
+
+
+def main():
+    rows = fetch_rows(limit=5)
+    for row in rows:
+        process_row(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcq_video_pipeline/playlist.py
+++ b/mcq_video_pipeline/playlist.py
@@ -1,0 +1,34 @@
+"""Manage YouTube playlists."""
+from googleapiclient.discovery import build
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+YOUTUBE_CLIENT_SECRETS = os.getenv("YOUTUBE_CLIENT_SECRETS")
+
+youtube = build("youtube", "v3", developerKey=YOUTUBE_CLIENT_SECRETS)
+
+
+def get_or_create_playlist(subject: str) -> str:
+    request = youtube.playlists().list(part="snippet", mine=True, maxResults=50)
+    response = request.execute()
+    for item in response.get("items", []):
+        if item["snippet"]["title"] == subject:
+            return item["id"]
+    create_request = youtube.playlists().insert(
+        part="snippet,status",
+        body={
+            "snippet": {"title": subject},
+            "status": {"privacyStatus": "unlisted"},
+        },
+    )
+    create_response = create_request.execute()
+    return create_response.get("id")
+
+
+def add_video_to_playlist(video_id: str, playlist_id: str) -> None:
+    youtube.playlistItems().insert(
+        part="snippet",
+        body={"snippet": {"playlistId": playlist_id, "resourceId": {"kind": "youtube#video", "videoId": video_id}}},
+    ).execute()

--- a/mcq_video_pipeline/requirements.txt
+++ b/mcq_video_pipeline/requirements.txt
@@ -1,0 +1,10 @@
+gspread
+google-auth
+pandas
+gtts
+moviepy
+elevenlabs
+google-api-python-client
+google-auth-oauthlib
+google-auth-httplib2
+python-dotenv

--- a/mcq_video_pipeline/upload.py
+++ b/mcq_video_pipeline/upload.py
@@ -1,0 +1,30 @@
+"""Upload video to YouTube and Google Drive."""
+from pathlib import Path
+from typing import Dict
+import os
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from dotenv import load_dotenv
+
+load_dotenv()
+
+YOUTUBE_CLIENT_SECRETS = os.getenv("YOUTUBE_CLIENT_SECRETS")
+
+# Placeholder for Google Drive implementation
+
+def upload_to_youtube(video_path: Path, title: str, description: str) -> str:
+    """Upload video and return the YouTube video ID."""
+    youtube = build("youtube", "v3", developerKey=YOUTUBE_CLIENT_SECRETS)
+    body = {
+        "snippet": {"title": title, "description": description},
+        "status": {"privacyStatus": "unlisted"},
+    }
+    media = MediaFileUpload(video_path.as_posix(), mimetype="video/mp4")
+    request = youtube.videos().insert(part=",".join(body.keys()), body=body, media_body=media)
+    response = request.execute()
+    return response.get("id")
+
+
+def backup_to_drive(video_path: Path) -> None:
+    """Upload a copy to Google Drive."""
+    pass

--- a/mcq_video_pipeline/video_creation.py
+++ b/mcq_video_pipeline/video_creation.py
@@ -1,0 +1,33 @@
+"""Assemble video using moviepy."""
+from pathlib import Path
+from typing import Dict
+from moviepy.editor import (
+    AudioFileClip,
+    CompositeVideoClip,
+    concatenate_videoclips,
+    TextClip,
+)
+
+INTRO_PATH = "assets/intro.mp4"
+OUTRO_PATH = "assets/outro.mp4"
+
+
+def create_video(row: Dict[str, str], audio_path: Path, out_path: Path) -> Path:
+    question = row.get("Question", "")
+    answer = row.get("Answer", "")
+    explanation = row.get("Explanation", "")
+    tip = row.get("Strategy Tip", "")
+
+    intro = TextClip("Intro", fontsize=70, color="white", size=(1280, 720)).set_duration(3)
+    outro = TextClip("Outro", fontsize=70, color="white", size=(1280, 720)).set_duration(3)
+
+    question_clip = TextClip(question, fontsize=60, color="white", size=(1280, 720)).set_duration(5)
+    answer_clip = TextClip(f"Answer: {answer}", fontsize=60, color="yellow", size=(1280, 720)).set_duration(3)
+    explanation_clip = TextClip(explanation + " " + tip, fontsize=40, color="white", size=(1280, 720)).set_duration(8)
+
+    audio = AudioFileClip(audio_path.as_posix())
+
+    video = concatenate_videoclips([intro, question_clip, answer_clip, explanation_clip, outro])
+    video = video.set_audio(audio)
+    video.write_videofile(out_path.as_posix(), fps=24)
+    return out_path

--- a/mcq_video_pipeline/voiceover.py
+++ b/mcq_video_pipeline/voiceover.py
@@ -1,0 +1,28 @@
+"""Generate voiceover audio."""
+from pathlib import Path
+from typing import Optional
+import os
+from dotenv import load_dotenv
+
+from gtts import gTTS
+
+try:
+    from elevenlabs import generate
+except Exception:
+    generate = None
+
+load_dotenv()
+
+ELEVEN_LABS_KEY = os.getenv("ELEVEN_LABS_KEY")
+
+
+def create_voiceover(text: str, out_path: Path) -> Path:
+    """Create an MP3 voiceover using ElevenLabs if available, else gTTS."""
+    if ELEVEN_LABS_KEY and generate:
+        audio = generate(text=text, api_key=ELEVEN_LABS_KEY)
+        with open(out_path, "wb") as f:
+            f.write(audio)
+    else:
+        tts = gTTS(text)
+        tts.save(out_path.as_posix())
+    return out_path


### PR DESCRIPTION
## Summary
- add modular pipeline under `mcq_video_pipeline`
- document directory structure and environment variables
- include requirements for the new pipeline
- update repo README with link to new scaffold
- add `.gitignore`

## Testing
- `python -m py_compile mcq_video_pipeline/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686b4525937c832eab270b7d637d66d5